### PR TITLE
Fix document

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Simple rake task generator for oneshot tasks.
 
 ```sh
-$ bin/rake generate oneshot FooBar
+$ bin/rails generate oneshot FooBar
       create  lib/tasks/oneshot/20180205_foo_bar.rake
 ```
 


### PR DESCRIPTION
This task not defined in the Rakefile.

```
% bin/rake generate oneshot FooBar
Running via Spring preloader in process 28007
rake aborted!
Don't know how to build task 'generate' (see --tasks)
-e:1:in `<main>'
(See full trace by running task with --trace)
```