### PR TITLE
Use Ruby 2.4.4 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.1
+  - 2.4.4
 before_install: gem install bundler -v 2.0.1


### PR DESCRIPTION
Rails 6 requires zeitwerk 2.1.9 and zeitwerk requires Ruby 2.4.4 or newer.
https://travis-ci.org/s-osa/oneshot_task_generator/builds/574128793?utm_source=github_status&utm_medium=notification