### PR TITLE
Avoid to insert trailing spaces on blank line

### DIFF
--- a/lib/generators/oneshot/templates/oneshot.rake.erb
+++ b/lib/generators/oneshot/templates/oneshot.rake.erb
@@ -6,9 +6,7 @@ namespace :oneshot do
   desc ''
   task <%= task_name %>: :environment do<%= configuration.arguments && " |#{configuration.arguments.join(", ")}|" %>
     <%- if configuration.body -%>
-    <%- configuration.body.each_line.map(&:chomp).each do |line| -%>
-    <%= line %>
-    <%- end -%>
+<%= configuration.body.indent(4) %>
     <%- end -%>
   end
 end

--- a/spec/generators/oneshot/oneshot_generator_spec.rb
+++ b/spec/generators/oneshot/oneshot_generator_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe OneshotGenerator, type: :generator do
         described_class.config.body = <<-BODY
 ActiveRecord::Base.transaction do
   # Write transactional code here
+
+  # blah
 end
         BODY
         example.run
@@ -63,9 +65,15 @@ end
       it 'inserts body' do
         file_name = Dir.glob("tmp/lib/tasks/oneshot/*").first
         generated_text = File.read(file_name)
-        expect(generated_text).to match(/^ {4}ActiveRecord::Base.transaction do$/)
-        expect(generated_text).to match(/^ {4}  # Write transactional code here$/)
-        expect(generated_text).to match(/^ {4}end$/)
+        # expected_body has 4 spaces indentation
+        expected_body = <<-BODY
+    ActiveRecord::Base.transaction do
+      # Write transactional code here
+
+      # blah
+    end
+        BODY
+        expect(generated_text).to include(expected_body)
       end
 
       it 'is valid as ruby' do


### PR DESCRIPTION
# Problem



The generator inserts trailing spaces if the template body has an empty line.
For example:


```ruby
OneshotGenerator.configure do |config|
  config.body = <<~'BODY'
    # foo

    # bar
  BODY
end
```

In this case, a generated task definition has 4 spaces between "# foo" and "# bar".


# Cause



Due to the ERB template.
It renders `    <%= line %>` with 4 spaces indentation even if the line is empty. So it only inserts 4 spaces unexpectedly if the `line` is just an empty string.



# Solution


Use `String#indent` instead of `each_line` and adding the indentation with ERB text.
Note that the `String#indent` method is added by Active Support.



# Spec


I also updated the spec to test the generator with an empty line.



