### PR TITLE
Unifyed task names to runtime task names

### DIFF
--- a/lib/generators/oneshot/oneshot_generator.rb
+++ b/lib/generators/oneshot/oneshot_generator.rb
@@ -10,12 +10,12 @@ class OneshotGenerator < Rails::Generators::NamedBase
   def setup
     @current   = Time.current
     @timestamp = @current.strftime('%Y%m%d')
-    @task_name = "#{name.underscore}_#{timestamp}"
+    @task_name = "#{timestamp}_#{name.underscore}"
     @configuration = self.class.configuration
   end
 
   def create_file_with_template
-    path = File.join(@configuration.directory, "#{timestamp}_#{name.underscore}.rake")
+    path = File.join(@configuration.directory, "#{task_name}.rake")
     template 'oneshot.rake.erb', path
   end
 end

--- a/lib/generators/oneshot/templates/oneshot.rake.erb
+++ b/lib/generators/oneshot/templates/oneshot.rake.erb
@@ -4,7 +4,7 @@
 <%= "# For copy and paste: `bin/rake oneshot:#{task_name}`" %>
 namespace :oneshot do
   desc ''
-  task <%= task_name %>: :environment do<%= configuration.arguments && " |#{configuration.arguments.join(", ")}|" %>
+  task <%= "'#{task_name}'" %>: :environment do<%= configuration.arguments && " |#{configuration.arguments.join(", ")}|" %>
     <%- if configuration.body -%>
 <%= configuration.body.indent(4) %>
     <%- end -%>

--- a/spec/generators/oneshot/oneshot_generator_spec.rb
+++ b/spec/generators/oneshot/oneshot_generator_spec.rb
@@ -97,7 +97,7 @@ end
       it 'inserts the arguments' do
         file_name = Dir.glob("tmp/lib/tasks/oneshot/*").first
         generated_text = File.read(file_name)
-        expect(generated_text).to match(/^  task foo_bar_\d{8}: :environment do \|task, args\|$/)
+        expect(generated_text).to match(/^  task '\d{8}_foo_bar': :environment do \|task, args\|$/)
       end
 
       it 'is valid as ruby' do


### PR DESCRIPTION
## Problem
The generated task name is not consistent with the runtime task name.
Therefore, I don't think it can be done intuitively.

### For example

generated task name： `20200530_foo_bar.rake`

```console
$ bin/rails generate oneshot foo_bar
Running via Spring preloader in process 93693
      create  lib/tasks/oneshot/20200530_foo_bar.rake
```

runtime task name： `foo_bar_20200530`

```console
$ bin/rake oneshot:foo_bar_20200530
```

## Solution
I unifyed task names to runtime task names.

### For example

generated task name： `foo_bar_20200530.rake`

```console
$ bin/rails generate oneshot foo_bar
Running via Spring preloader in process 93857
      create  lib/tasks/oneshot/foo_bar_20200530.rake
```

runtime task name： `foo_bar_20200530`

```console
$ bin/rake oneshot:foo_bar_20200530
```

## Spec
I checked the file generated by the modified source and modified the RSpec.